### PR TITLE
Fix ./machnet script and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ RUN git clone --depth 1 --branch 'v21.11' https://github.com/DPDK/dpdk.git ${RTE
     DESTDIR=${RTE_SDK}/build/install ninja install && \
     rm -rf ${RTE_SDK}/app ${RTE_SDK}/drivers ${RTE_SDK}/.git ${RTE_SDK}/build/app
 
-
 # Stage 2: Build Machnet
 FROM machnet_build_base as machnet
 
@@ -65,7 +64,8 @@ WORKDIR /root/machnet
 COPY . .
 
 # Build Machnet
-RUN mkdir build && \
+RUN ldconfig && \
+    mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release -GNinja ../ && \
     ninja

--- a/machnet.sh
+++ b/machnet.sh
@@ -86,9 +86,9 @@ if ! groups | grep -q docker; then
 fi
 
 echo "Checking if the Machnet Docker image is available"
-if ! docker pull ghcr.io/msr-machnet/machnet:latest
+if ! docker pull ghcr.io/microsoft/machnet/machnet:latest
 then
-    echo "Please make sure you have access to the Machnet Docker image at ghcr.io/msr-machnet/machnet"
+    echo "Please make sure you have access to the Machnet Docker image at ghcr.io/microsoft/machnet/"
     echo "See Machnet README for instructions on how to get access"
 fi
 
@@ -118,7 +118,7 @@ else
     sudo docker run --privileged --net=host \
         -v /dev/hugepages:/dev/hugepages \
         -v /var/run/machnet:/var/run/machnet \
-        ghcr.io/msr-machnet/machnet:latest \
+        ghcr.io/microsoft/machnet/machnet:latest \
         /root/machnet/build/src/apps/machnet/machnet \
         --config_json /var/run/machnet/local_config.json \
         --logtostderr=1


### PR DESCRIPTION
It uses consistent naming in `./machnet.sh` script to use the latest published container image. 

Docker run `ldconfig` before building machnet to solve the shared library not found error.

Best,
Vahab