### PR TITLE
fixing issue #3, Build system should not assume an address for DPDK

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,7 @@ endif()
 
 # DPDK.
 if(NOT DEFINED ENV{RTE_SDK})
-  set(RTE_SDK "$ENV{HOME}/dpdk")
-  message(STATUS "RTE_SDK is not defined; setting to: ${RTE_SDK}")
+  message(FATAL_ERROR "RTE_SDK is not defined;")
 else()
   set(RTE_SDK $ENV{RTE_SDK})
 endif()


### PR DESCRIPTION
Without this, it might be more convenient to build machnet. But if you have a different location rather than `/home/<user>/dpdk,` then it might confuse developers. Giving an error here is useful in general, instead of setting it to a presumed address.