### PR TITLE
Some renaming for flow.h

### DIFF
--- a/src/include/flow.h
+++ b/src/include/flow.h
@@ -47,9 +47,9 @@ class TXTracking {
   const uint32_t NumUnsentMsgbufs() const { return num_unsent_msgbufs_; }
   shm::MsgBuf* GetOldestUnackedMsgBuf() const { return oldest_unacked_msgbuf_; }
 
-  void ReceiveAcks(uint32_t num_acks) {
+  void ReceiveAcks(uint32_t num_acked_pkts) {
     shm::MsgBufBatch to_free;
-    while (num_acks) {
+    while (num_acked_pkts) {
       auto msgbuf = oldest_unacked_msgbuf_;
       DCHECK(msgbuf != nullptr);
       if (msgbuf != last_msgbuf_) {
@@ -65,7 +65,7 @@ class TXTracking {
         num_tracked_msgbufs_ -= to_free.GetSize();
         CHECK(channel_->MsgBufBulkFree(&to_free));
       }
-      num_acks--;
+      num_acked_pkts--;
     }
 
     num_tracked_msgbufs_ -= to_free.GetSize();


### PR DESCRIPTION
- Avoid names `TXQueue` and `RXQueue`, which can be confused with NIC TX/RQ queues.
- Use more descriptive names for `TXTracking` methods, e.g.:
  - `Push()` suggests sending packets on the wire. Rename to `Append` instead.
  - `Pop()` suggests that (1) the oldest un-acked packet (not oldest unsent packet) will be popped, and (2) packets will be freed as part of the `Pop()`. Rename to `GetAndUpdateOldestUnsent`.

- Move some methods use for testing only to private methods.