### PR TITLE
Update PKG_CONFIG_PATH for dpdk setup on Ubuntu

### DIFF
--- a/docs/INTERNAL.md
+++ b/docs/INTERNAL.md
@@ -64,8 +64,10 @@ cd dpdk-23.11
 meson build --prefix=${PWD}/build/install/usr/local
 ninja -C build
 ninja -C build install
-export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig"
+export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig" or export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/pkgconfig"
 ```
+
+Note: You can find the PKG_CONFIG_PATH by the following command: find *path_to_dpdk* -name "*.pc".
 
 ### Build Machnet
 

--- a/docs/INTERNAL.md
+++ b/docs/INTERNAL.md
@@ -64,7 +64,7 @@ cd dpdk-23.11
 meson build --prefix=${PWD}/build/install/usr/local
 ninja -C build
 ninja -C build install
-export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/pkgconfig"
+export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig"
 ```
 
 ### Build Machnet

--- a/docs/INTERNAL.md
+++ b/docs/INTERNAL.md
@@ -64,7 +64,7 @@ cd dpdk-23.11
 meson build --prefix=${PWD}/build/install/usr/local
 ninja -C build
 ninja -C build install
-export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig" or export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/pkgconfig"
+export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig:${PWD}/build/install/usr/local/lib/pkgconfig"
 ```
 
 Note: You can find the PKG_CONFIG_PATH by the following command: find *path_to_dpdk* -name "*.pc".


### PR DESCRIPTION
Present: The location of PKG_CONFIG_PATH does not reflect the correct location of pkgconfig upon dpdk installation

proposed: correct path as installed by dpdk