### PR TITLE
docs/INTERNAL.md: fix DPDK dynamic library linking.

### DIFF
--- a/docs/INTERNAL.md
+++ b/docs/INTERNAL.md
@@ -11,9 +11,9 @@ docker build --no-cache -f dockerfiles/ubuntu-22.04.dockerfile --target machnet 
 
 ### Building custom images
 
-The top-level makefile allows building x86 and arm64 docker images across a 
-variety of microarchitecture capability levels (x86) or SOC targets (arm64). 
-Invoking "make" will create them for the architecture of the host. 
+The top-level makefile allows building x86 and arm64 docker images across a
+variety of microarchitecture capability levels (x86) or SOC targets (arm64).
+Invoking "make" will create them for the architecture of the host.
 
 To build a Machnet image for a specific architecture, e.g, x86-64-v4
 
@@ -64,7 +64,9 @@ cd dpdk-23.11
 meson build --prefix=${PWD}/build/install/usr/local
 ninja -C build
 ninja -C build install
-export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig:${PWD}/build/install/usr/local/lib/pkgconfig"
+export PKG_CONFIG_PATH="${PWD}/build/install/usr/local/lib/x86_64-linux-gnu/pkgconfig"
+echo "${PWD}/build/install/usr/local/lib/x86_64-linux-gnu" | sudo tee -a /etc/ld.so.conf.d/x86_64-linux-gnu.conf > /dev/null
+sudo ldconfig
 ```
 
 Note: You can find the PKG_CONFIG_PATH by the following command: find *path_to_dpdk* -name "*.pc".


### PR DESCRIPTION
Hi Anuj && Ilias

These extra steps need to be taken to fix the documentation so that Machnet can run.

I will look for a fix to stick with the static library, but apparently, Machnet is dynamically linked with DPDK, so these steps need to be taken.

Please have a look.

Thanks,
Alireza
